### PR TITLE
Added audio visualizer to the BeestFeest RAGweek screen

### DIFF
--- a/beestfeest-ragweek-plugin/assets/css/audio-visualizer.css
+++ b/beestfeest-ragweek-plugin/assets/css/audio-visualizer.css
@@ -1,0 +1,29 @@
+html, body.bfrw-body {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    background-color: black;
+}
+
+div.audio-visualizer-wrapper {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+}
+
+svg.visualizer {
+    display: block;
+    width: 100%;
+    height: 80%;
+    padding: 0;
+    margin: 0;
+    top: 0;
+    position: absolute;
+}
+
+path {
+    stroke-linecap: square;
+    stroke: white;
+    stroke-width: 1px;
+}

--- a/beestfeest-ragweek-plugin/assets/css/audio-visualizer.css
+++ b/beestfeest-ragweek-plugin/assets/css/audio-visualizer.css
@@ -3,7 +3,7 @@ html, body.bfrw-body {
     height: 100%;
     padding: 0;
     margin: 0;
-    background-color: black;
+    background-color: #1a1a1a;
 }
 
 div.audio-visualizer-wrapper {

--- a/beestfeest-ragweek-plugin/assets/js/audio-visualizer.js
+++ b/beestfeest-ragweek-plugin/assets/js/audio-visualizer.js
@@ -1,0 +1,49 @@
+
+
+class AudioVisualizer {
+
+    constructor(visualizer, audioContent, stream) {
+        this.visualizer = visualizer;
+        visualizer.setAttribute('viewBox', '0 0 255 255');
+        this.running = false;
+        this.audioStream = audioContent.createMediaStreamSource(stream);
+        this.analyzer = audioContent.createAnalyser();
+        this.analyzer.fftSize = 1024;
+        this.audioStream.connect(this.analyzer);
+        this.paths = [];
+        let mask = this.visualizer.getElementById('mask');
+        for (let i = 0; i < this.analyzer.frequencyBinCount; i++) {
+            let path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute('stroke-dasharray', '4,1');
+            mask.appendChild(path);
+            this.paths.push(path);
+        }
+    }
+
+    run() {
+        this.running = true;
+        this.doDraw();
+    }
+
+    stop() {
+        this.running = false;
+    }
+
+    doDraw() {
+        if (this.running) {
+            requestAnimationFrame(() => {
+                this.doDraw();
+            });
+            let frequencyArray = new Uint8Array(this.analyzer.frequencyBinCount);
+            this.analyzer.getByteFrequencyData(frequencyArray);
+            for (let i = 0; i < this.analyzer.frequencyBinCount; i++) {
+                let adjustedLength = Math.floor(frequencyArray[i]) - (Math.floor(frequencyArray[i]) % 5);
+                this.paths[i].setAttribute('d', 'M ' + (i) + ',255 l 0,-' + adjustedLength);
+            }
+        } else {
+            for (let i = 0; i < 255; i++) {
+                this.paths[i].setAttribute('d', 'M ' + (i) + ',255 l 0,-' + 0);
+            }
+        }
+    }
+}

--- a/beestfeest-ragweek-plugin/includes/bfrw-functions.php
+++ b/beestfeest-ragweek-plugin/includes/bfrw-functions.php
@@ -114,7 +114,11 @@ if ( ! function_exists( 'bfrw_override_template' ) ) {
 	function bfrw_override_template( string $template ): string {
 		global $post;
 		if ( has_shortcode( $post->post_content, 'bfrw-ragweek' ) ) {
-			return BFRW_ABSPATH . 'views/ragweek.php';
+			if ( isset( $_GET['visualizer'] ) && 'audio' === $_GET['visualizer'] ) {
+				return BFRW_ABSPATH . 'views/ragweek-audio-visualizer.php';
+			} else {
+				return BFRW_ABSPATH . 'views/ragweek.php';
+			}
 		} else {
 			return $template;
 		}

--- a/beestfeest-ragweek-plugin/views/ragweek-audio-visualizer.php
+++ b/beestfeest-ragweek-plugin/views/ragweek-audio-visualizer.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * BeestFeest RAGweek Audio visualizer page
+ *
+ * @package beestfeest-ragweek-plugin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+wp_enqueue_script( 'bfrw-ragweek-script', BFRW_PLUGIN_URI . 'assets/js/board.js', array( 'jquery' ), '1.0', true );
+wp_enqueue_script( 'jquery' );
+wp_enqueue_style( 'bfrw-styles', BFRW_PLUGIN_URI . 'assets/css/ragweek.css', array(), '1.1' );
+wp_enqueue_script( 'bfrw-audio-visualizer-script', BFRW_PLUGIN_URI . 'assets/js/audio-visualizer.js', array(), '1.0', true );
+wp_enqueue_style( 'bfrw-audio-visualizer-styles', BFRW_PLUGIN_URI . 'assets/css/audio-visualizer.css', array(), '1.0' );
+?>
+<!doctype html>
+<html <?php language_attributes(); ?>>
+    <head>
+        <meta charset="<?php bloginfo( 'charset' ); ?>">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+	    <?php wp_head(); ?>
+    </head>
+
+    <body <?php body_class( 'bfrw-body' ); ?>>
+        <?php wp_body_open(); ?>
+        <div class="bfrw-wrapper">
+            <div class="audio-visualizer-wrapper">
+                <svg preserveAspectRatio="none" class="visualizer" version="1.1" id="visualizer" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <defs>
+                        <mask id="mask">
+                            <g id="maskGroup"></g>
+                        </mask>
+                        <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                            <stop offset="0%" style="stop-color:#db6247;stop-opacity:1" />
+                            <stop offset="40%" style="stop-color:#f6e5d1;stop-opacity:1" />
+                            <stop offset="60%" style="stop-color:#5c79c7;stop-opacity:1" />
+                            <stop offset="85%" style="stop-color:#b758c0;stop-opacity:1" />
+                            <stop offset="100%" style="stop-color:#222;stop-opacity:1" />
+                        </linearGradient>
+                    </defs>
+                    <rect x="0" y="0" width="100%" height="100%" fill="url(#gradient)" mask="url(#mask)"></rect>
+                </svg>
+            </div>
+
+            <img src="<?php echo esc_attr( BFRW_PLUGIN_URI . 'assets/img/beestfeestletters.png' ); ?>" class="bfrw-top-centered" />
+            <div class="bfrw-songs">
+                <ul id="songs">
+                </ul>
+            </div>
+
+            <div class="bfrw-bottom-fixed">
+                <img src="<?php echo esc_attr( BFRW_PLUGIN_URI . 'assets/img/gradient.png' ); ?>" class="gradient" />
+                <div class="full-width">
+                    <div class="messages">
+                        <marquee behavior="scroll" direction="left" class="messages-scroller" id="scroller"></marquee>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <?php wp_print_footer_scripts(); ?>
+        <script>
+            AudioContext = window.AudioContext || window.webkitAudioContext;
+            audioContent = new AudioContext();
+
+            navigator.mediaDevices.getUserMedia( { audio: true } )
+                .then((stream) => {
+                    let audioVisualizer = new AudioVisualizer(document.getElementById('visualizer'), audioContent, stream);
+                    audioVisualizer.run();
+                })
+                .catch((e) => {
+                    console.error(e);
+                    alert( "Could not get permission to enable the sound device, please reload this page." )
+                });
+        </script>
+	</body>
+</html>

--- a/beestfeest-ragweek-plugin/views/ragweek-audio-visualizer.php
+++ b/beestfeest-ragweek-plugin/views/ragweek-audio-visualizer.php
@@ -16,63 +16,63 @@ wp_enqueue_style( 'bfrw-audio-visualizer-styles', BFRW_PLUGIN_URI . 'assets/css/
 ?>
 <!doctype html>
 <html <?php language_attributes(); ?>>
-    <head>
-        <meta charset="<?php bloginfo( 'charset' ); ?>">
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-	    <?php wp_head(); ?>
-    </head>
+	<head>
+		<meta charset="<?php bloginfo( 'charset' ); ?>">
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<?php wp_head(); ?>
+	</head>
 
-    <body <?php body_class( 'bfrw-body' ); ?>>
-        <?php wp_body_open(); ?>
-        <div class="bfrw-wrapper">
-            <div class="audio-visualizer-wrapper">
-                <svg preserveAspectRatio="none" class="visualizer" version="1.1" id="visualizer" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <defs>
-                        <mask id="mask">
-                            <g id="maskGroup"></g>
-                        </mask>
-                        <linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                            <stop offset="0%" style="stop-color:#db6247;stop-opacity:1" />
-                            <stop offset="40%" style="stop-color:#f6e5d1;stop-opacity:1" />
-                            <stop offset="60%" style="stop-color:#5c79c7;stop-opacity:1" />
-                            <stop offset="85%" style="stop-color:#b758c0;stop-opacity:1" />
-                            <stop offset="100%" style="stop-color:#222;stop-opacity:1" />
-                        </linearGradient>
-                    </defs>
-                    <rect x="0" y="0" width="100%" height="100%" fill="url(#gradient)" mask="url(#mask)"></rect>
-                </svg>
-            </div>
+	<body <?php body_class( 'bfrw-body' ); ?>>
+		<?php wp_body_open(); ?>
+		<div class="bfrw-wrapper">
+			<div class="audio-visualizer-wrapper">
+				<svg preserveAspectRatio="none" class="visualizer" version="1.1" id="visualizer" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+					<defs>
+						<mask id="mask">
+							<g id="maskGroup"></g>
+						</mask>
+						<linearGradient id="gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+							<stop offset="0%" style="stop-color:#db6247;stop-opacity:1" />
+							<stop offset="40%" style="stop-color:#f6e5d1;stop-opacity:1" />
+							<stop offset="60%" style="stop-color:#5c79c7;stop-opacity:1" />
+							<stop offset="85%" style="stop-color:#b758c0;stop-opacity:1" />
+							<stop offset="100%" style="stop-color:#222;stop-opacity:1" />
+						</linearGradient>
+					</defs>
+					<rect x="0" y="0" width="100%" height="100%" fill="url(#gradient)" mask="url(#mask)"></rect>
+				</svg>
+			</div>
 
-            <img src="<?php echo esc_attr( BFRW_PLUGIN_URI . 'assets/img/beestfeestletters.png' ); ?>" class="bfrw-top-centered" />
-            <div class="bfrw-songs">
-                <ul id="songs">
-                </ul>
-            </div>
+			<img src="<?php echo esc_attr( BFRW_PLUGIN_URI . 'assets/img/beestfeestletters.png' ); ?>" class="bfrw-top-centered" />
+			<div class="bfrw-songs">
+				<ul id="songs">
+				</ul>
+			</div>
 
-            <div class="bfrw-bottom-fixed">
-                <img src="<?php echo esc_attr( BFRW_PLUGIN_URI . 'assets/img/gradient.png' ); ?>" class="gradient" />
-                <div class="full-width">
-                    <div class="messages">
-                        <marquee behavior="scroll" direction="left" class="messages-scroller" id="scroller"></marquee>
-                    </div>
-                </div>
-            </div>
-        </div>
+			<div class="bfrw-bottom-fixed">
+				<img src="<?php echo esc_attr( BFRW_PLUGIN_URI . 'assets/img/gradient.png' ); ?>" class="gradient" />
+				<div class="full-width">
+					<div class="messages">
+						<marquee behavior="scroll" direction="left" class="messages-scroller" id="scroller"></marquee>
+					</div>
+				</div>
+			</div>
+		</div>
 
-        <?php wp_print_footer_scripts(); ?>
-        <script>
-            AudioContext = window.AudioContext || window.webkitAudioContext;
-            audioContent = new AudioContext();
+		<?php wp_print_footer_scripts(); ?>
+		<script>
+			AudioContext = window.AudioContext || window.webkitAudioContext;
+			audioContent = new AudioContext();
 
-            navigator.mediaDevices.getUserMedia( { audio: true } )
-                .then((stream) => {
-                    let audioVisualizer = new AudioVisualizer(document.getElementById('visualizer'), audioContent, stream);
-                    audioVisualizer.run();
-                })
-                .catch((e) => {
-                    console.error(e);
-                    alert( "Could not get permission to enable the sound device, please reload this page." )
-                });
-        </script>
+			navigator.mediaDevices.getUserMedia( { audio: true } )
+				.then((stream) => {
+					let audioVisualizer = new AudioVisualizer(document.getElementById('visualizer'), audioContent, stream);
+					audioVisualizer.run();
+				})
+				.catch((e) => {
+					console.error(e);
+					alert( "Could not get permission to enable the sound device, please reload this page." )
+				});
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
It is now possible to view an audio analyzer when visiting the RAGweek page and adding a `?visualizer=audio` GET parameter.